### PR TITLE
chore: fix button layout

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -341,23 +341,36 @@ body {
 .ags-button-row {
     display: flex;
     flex-wrap: nowrap;
-    justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
+    flex-direction: column-reverse;
+    gap: 20px;
 }
 
 .ags-submit-container {
     display: flex;
     flex-direction: column-reverse;
     gap: 20px;
+    width: 100%;
+}
+
+@media screen and (min-width: 480px) and (max-width: 991px) {
+    .ags-button-row {
+        max-width: 50%;
+        margin-left: auto;
+        margin-right: auto;
+    }
 }
 
 @media screen and (min-width: 992px) {
     .ags-button-row {
         align-items: center;
+        justify-content: space-between;
+        flex-direction: row;
     }
 
     .ags-submit-container {
         flex-direction: row;
+        width: auto;
     }
 }
 
@@ -375,7 +388,7 @@ body {
 }
 
 .ags-toggle-text {
-    font-size: 0.875;
+    font-size: 0.875rem;
     color: var(--text-color);
     display: inline-flex;
     align-items: center;

--- a/css/app.css
+++ b/css/app.css
@@ -12,6 +12,26 @@
     --gray-color: #c0c0c0;
 }
 
+/* clears the 'X' from Internet Explorer */
+input[type="search"]::-ms-clear {
+    display: none;
+    width: 0;
+    height: 0;
+}
+input[type="search"]::-ms-reveal {
+    display: none;
+    width: 0;
+    height: 0;
+}
+
+/* clears the 'X' from Chrome */
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button,
+input[type="search"]::-webkit-search-results-decoration {
+    display: none;
+}
+
 * {
     -webkit-tap-highlight-color: transparent;
 }
@@ -321,13 +341,24 @@ body {
 .ags-button-row {
     display: flex;
     flex-wrap: nowrap;
-    align-items: center;
+    justify-content: space-between;
+    align-items: flex-start;
 }
 
 .ags-submit-container {
     display: flex;
-    justify-content: center;
-    flex: 1;
+    flex-direction: column-reverse;
+    gap: 20px;
+}
+
+@media screen and (min-width: 992px) {
+    .ags-button-row {
+        align-items: center;
+    }
+
+    .ags-submit-container {
+        flex-direction: row;
+    }
 }
 
 .ags-toggle-container {

--- a/index.html
+++ b/index.html
@@ -46,7 +46,11 @@
     </head>
     <body x-data="searchForm" x-init="getLists">
         <div class="ags-app">
-            <form @submit.prevent="submit" class="ags-form">
+            <form
+                @submit.prevent="submit"
+                class="ags-form"
+                @change="setIsDirty"
+            >
                 <div class="ags-form-row">
                     <label for="nev" class="ags-label">Nyertes neve:</label>
                     <div class="ags-icon-wrapper">
@@ -395,14 +399,13 @@
                     <div class="ags-submit-container">
                         <button
                             type="button"
-                            class="ags-button"
+                            class="ags-button ags-button-secondary"
                             @click="clearSearchFields()"
                             x-cloak
+                            x-show="isDirty"
                         >
                             Keresés törlése
                         </button>
-                    </div>
-                    <div class="ags-submit-container">
                         <button
                             type="submit"
                             class="ags-button"

--- a/js/agrar.js
+++ b/js/agrar.js
@@ -29,6 +29,7 @@ document.addEventListener("alpine:init", () => {
             tamogatasosszeg: null,
             evestamogatasosszeg: null,
         },
+        isDirty: false,
         per_page: 15,
         submitText: "Keresés",
         submitting: false,
@@ -150,6 +151,7 @@ document.addEventListener("alpine:init", () => {
             this.formData.tamogatott = null;
             this.setTamosszegDefaults();
             this.setEvestamosszegDefaults();
+            this.isDirty = false;
         },
         clearResults() {
             this.resultData = [];
@@ -441,6 +443,9 @@ document.addEventListener("alpine:init", () => {
                             (values) => {
                                 this.formData.tamosszegtol = values[0];
                                 this.formData.tamosszegig = values[1];
+                                // have to trigger this manually on all the slider changes
+                                // cause the <form>'s onChange doesn't get fired when the sliders get changed
+                                this.setIsDirty();
                             }
                         );
                         this.$watch("formData.tamosszegtol", () => {
@@ -488,6 +493,9 @@ document.addEventListener("alpine:init", () => {
                             (values) => {
                                 this.formData.evestamosszegtol = values[0];
                                 this.formData.evestamosszegig = values[1];
+                                // have to trigger this manually on all the slider changes
+                                // cause the <form>'s onChange doesn't get fired when the sliders get changed
+                                this.setIsDirty();
                             }
                         );
                         this.$watch("formData.evestamosszegtol", () => {
@@ -560,6 +568,9 @@ document.addEventListener("alpine:init", () => {
         },
         submit() {
             this.search(API_URL + "/api/search");
+        },
+        setIsDirty() {
+            this.isDirty = true;
         },
         search(url) {
             this.disableSubmitBtn();


### PR DESCRIPTION
- fix button layout (align both to the right on desktop and make them fall under each other in mobile)
- apply secondary button styles to the "clear search" button
- make the "clear search" button appear only when the form is NOT in it's default state
- remove the built in "X" from the right side of `input[type="searc"]`